### PR TITLE
global_timer: fixed for both autonomous and joystick mode

### DIFF
--- a/revvy/revvy_utils.py
+++ b/revvy/revvy_utils.py
@@ -65,6 +65,7 @@ class RobotBLEController:
         }
 
         revvy_ble['live_message_service'].register_message_handler(rcs.data_ready)
+        revvy_ble['live_message_service'].register_on_joystick_action(rc.on_joystick_action)
         revvy_ble.on_connection_changed(self._on_connection_changed)
 
         self._scripts = ScriptManager(self)


### PR DESCRIPTION
In joystick control mode global_timer incorrectly started to count as soon as 'play' was pressed.

This is because 'self._processing' variable in RemoteController class was incorrectly set to True. Same flag has to be controlled more precisely with help of additional callback, on_joystick_action that could tell when its time to start counting the global_timer