### PR TITLE
Bugfix/variable not updated from user script

### DIFF
--- a/revvy/robot/imu.py
+++ b/revvy/robot/imu.py
@@ -59,5 +59,5 @@ class IMU:
     def update_orientation_data(self, data):
         values = struct.unpack('<fff', data)
         self._orientation = Orientation3D(*values)
-        print('update_orientation_data', values)
+        # print('update_orientation_data', values)
 

--- a/revvy/utils/functions.py
+++ b/revvy/utils/functions.py
@@ -204,9 +204,11 @@ def str_to_func(code, script_id=None):
 
         def ReportVariableChanged(name, value, scr_id=script_id, ls=list_slots):
             for variable_slot in ls:
-                if variable_slot.script_id is scr_id:
-                    if variable_slot.name is name:
+                if variable_slot.script_id == scr_id:
+                    if variable_slot.name == name:
                         variable_slot.value = value
+                        return
+            print(f'ReportVariableChanged: variable "{name}" not found')
 
         kwargs['ReportVariableChanged'] = ReportVariableChanged
 


### PR DESCRIPTION
This fixes a problem when user scripts could not update script variable.
Problem was:
1. When user script sets new value to variable, ReportVariableChanged function is called with variable name and value
2. ReportVariableChanged function searches for the variable object in variable storage by matching variable name and script id
3. Search code failed to match the name, because identity operator "is" was used to mactch name strings. Equality operator  "==" should be used instead.

In python matching strings with this method "if string_a is string_b" is incorrect, because it will return true only if string_a and string_b point to the same object in memory. That might be the case in some situations when python does opimization of storing the same strings, but in general it will return False for strings that are actually equal

Other identity operator for script_id matching is also removed due to same reason, although it is int 