### PR TITLE
Robot config refactor

### DIFF
--- a/revvy/robot_config.py
+++ b/revvy/robot_config.py
@@ -123,32 +123,29 @@ class RobotConfig:
 
                 assignments = script['assignments']
                 # script names are mostly relevant for logging
-                if 'analog' in assignments:
-                    for analog_assignment in assignments['analog']:
-                        channels = ', '.join(map(str, analog_assignment['channels']))
-                        script_name = f'[script {i}] analog channels {channels}'
-                        priority = analog_assignment['priority']
-                        config.controller.analog.append({
-                            'channels': analog_assignment['channels'],
-                            'script': ScriptDescriptor(script_name, runnable, priority)})
-                        i += 1
+                for analog_assignment in assignments.setdefault('analog', []):
+                    channels = ', '.join(map(str, analog_assignment['channels']))
+                    script_name = f'[script {i}] analog channels {channels}'
+                    priority = analog_assignment['priority']
+                    config.controller.analog.append({
+                        'channels': analog_assignment['channels'],
+                        'script': ScriptDescriptor(script_name, runnable, priority)})
+                    i += 1
 
-                if 'variableSlots' in assignments:
-                    for variable_assignments in assignments['variableSlots']:
-                        variable_slot = variable_assignments['slot']
-                        variable_name = variable_assignments['variable']
-                        config.controller.variable_slots.append({'slot': variable_slot,
-                                                                 'variable': variable_name,
-                                                                 'script': i,
-                                                                 })
+                for variable_assignments in assignments.setdefault('variableSlots', []):
+                    variable_slot = variable_assignments['slot']
+                    variable_name = variable_assignments['variable']
+                    config.controller.variable_slots.append({'slot': variable_slot,
+                                                             'variable': variable_name,
+                                                             'script': i,
+                                                             })
 
-                if 'buttons' in assignments:
-                    for button_assignment in assignments['buttons']:
-                        button_id = button_assignment['id']
-                        script_name = f'[script {i}] button {button_id}'
-                        priority = button_assignment['priority']
-                        config.controller.buttons[button_id] = ScriptDescriptor(script_name, runnable, priority)
-                        i += 1
+                for button_assignment in assignments.setdefault('buttons', []):
+                    button_id = button_assignment['id']
+                    script_name = f'[script {i}] button {button_id}'
+                    priority = button_assignment['priority']
+                    config.controller.buttons[button_id] = ScriptDescriptor(script_name, runnable, priority)
+                    i += 1
 
                 if 'background' in assignments:
                     script_name = f'[script {i}] background'

--- a/revvy/utils/functions.py
+++ b/revvy/utils/functions.py
@@ -152,25 +152,6 @@ def bits_to_bool_list(byte_list):
     return [is_bit_set(b, bit) for b in byte_list for bit in range(8)]
 
 
-def dict_get_first(dictionary: dict, keys: list):
-    """
-    Read a value from a dictionary, using multiple possible keys
-
-    >>> dict_get_first({'a': 'foo', 'b': 'bar', 'c': 'foobar'}, ['b', 'c'])
-    'bar'
-    >>> dict_get_first({'a': 'foo', 'b': 'bar', 'c': 'foobar'}, ['d', 'c'])
-    'foobar'
-    >>> dict_get_first({'a': 'foo', 'b': 'bar', 'c': 'foobar'}, ['e', 'f'])
-    Traceback (most recent call last):
-    ...
-    KeyError: 'e, f'
-    """
-    for key in keys:
-        with suppress(KeyError):
-            return dictionary[key]
-    raise KeyError(', '.join(keys))
-
-
 # noinspection SpellCheckingInspection
 def bytestr_hash(byte_str) -> str:
     hash_fn = hashlib.md5()


### PR DESCRIPTION
Refactoring robot config for readability and maintainability (Logic not changed)

Robot config lacks readability. following changes improve overall
code readability issues:
dict_get_first:
- function documentation removed
- raise KeyError removed
- function returns None if keys not found
- this remove need to create nested try..except blocks to use the
  function
- moved from separate py to the same file where it is only used

Create runnable become more readable with less nested indentation
and try-except blocks

First parsing steps in 'from_string' became more readable

Combination of "if key in dict:\n for i in dict[key]:\n" leads to
double indentation.
Using python syntax for dicts setdefault, we can turn this into
simpler line removing unwanted indentation and improving code
readability

Logic and functionality have not changed