### PR TITLE
Refactor/robot configuration processing

### DIFF
--- a/revvy/robot_config.py
+++ b/revvy/robot_config.py
@@ -165,6 +165,10 @@ class RobotConfig:
         initial_state = dict_get_first(json_config, ['initialState', 'initialstate'])
         if initial_state:
             config.background_initial_state = initial_state
+        else:
+            # If 'initialState' is not set, default is 'running' which will start all
+            # background scripts at the start of play session.
+            config.background_initial_state = 'running'
 
         try:
             for script_idx, script in enumerate(blockly_list):
@@ -222,7 +226,7 @@ class RobotConfig:
         self.drivetrain = {'left': [], 'right': []}
         self.controller = RemoteControlConfig()
         self.background_scripts = []
-        self.background_initial_state = 'running'
+        self.background_initial_state = None
 
 
 empty_robot_config = RobotConfig()


### PR DESCRIPTION
- default "initialstate" still set as 'running' but been written down more "explicitly" for readability.
- comments added why robot assumes missing parameter as running for joystick mode
- script processing code moved to separate function with no change of logic in respective commit.
- script naming formalized and put into helper functions
