### PR TITLE
Manual flasher script

### DIFF
--- a/mcu-firmware/tools/flash_latest.sh
+++ b/mcu-firmware/tools/flash_latest.sh
@@ -8,7 +8,7 @@ last_bin_file=$(find "$output_folder" -type f -name "*.bin" | sort | tail -n 1)
 # Check if a .bin file was found
 if [ -n "$last_bin_file" ]; then
     echo "Last .bin file found: $last_bin_file"
-    probe-rs download $output_folder/revvy_firmware-0.2.1235-main.bin --format bin --chip atsamd51p19a --base-address 0x40000
+    probe-rs download $last_bin_file --format bin --chip atsamd51p19a --base-address 0x40000
 else
     echo "No .bin files found in $output_folder. Not flashing."
 fi


### PR DESCRIPTION
flashed the latest build bin in the Build/output folder to the chip with the progress bar.

The reason this exists:
simple fallback and doc how to flash the firmware manually.