### PR TITLE
Restore automatic versioning

### DIFF
--- a/pi-firmware/tools/common.py
+++ b/pi-firmware/tools/common.py
@@ -16,8 +16,7 @@ def find_files(pathname):
 
 
 def get_version():
-
-    version = os.popen('cat version').read()
+    version = os.popen('git rev-list --count HEAD').read()
     print('version', version)
     version = version.strip()
 


### PR DESCRIPTION
cat doesn't work on windows (why was it even used...?) so let's just revert to the old way of versioning. we can do better if anyone has concerns