### PR TITLE
Enable flashing in vscode

### DIFF
--- a/mcu-firmware/.vscode/launch.json
+++ b/mcu-firmware/.vscode/launch.json
@@ -5,7 +5,8 @@
       "preLaunchTask": "prepare debug binary",
       "type": "probe-rs-debug",
       "flashingConfig": {
-        "haltAfterReset": true
+        "haltAfterReset": true,
+        "flashingEnabled": true,
       },
       "request": "launch",
       "name": "probe_rs Executable Test",


### PR DESCRIPTION
Weird because the default is already supposed to be `true` but with this change I can see a little popup saying "Programming..." so this must matter somewhere