### PR TITLE
Ensure rx buffer contents are not overwritten while processing

### DIFF
--- a/mcu-bootloader/rrrc/components/MasterCommunicationInterface/MasterCommunicationInterface.c
+++ b/mcu-bootloader/rrrc/components/MasterCommunicationInterface/MasterCommunicationInterface.c
@@ -107,5 +107,6 @@ void MasterCommunicationInterface_Call_OnTransmitComplete(void)
 
 void MasterCommunicationInterface_Run_SetResponse(const uint8_t* buffer, size_t bufferSize)
 {
+    i2c_hal_receive();
     i2c_hal_set_tx_buffer(buffer, bufferSize);
 }

--- a/mcu-bootloader/rrrc/components/MasterCommunicationInterface/i2cHal.c
+++ b/mcu-bootloader/rrrc/components/MasterCommunicationInterface/i2cHal.c
@@ -98,7 +98,6 @@ static void i2c_hal_on_address_matched(const uint8_t dir)
 {
     if (dir == I2C_DIR_MASTER_TX)
     {
-        descriptor.rxBufferCount = 0u;
         i2c_hal_rx_started();
     }
     else

--- a/mcu-firmware/rrrc/components/MasterCommunicationInterface/MasterCommunicationInterface.c
+++ b/mcu-firmware/rrrc/components/MasterCommunicationInterface/MasterCommunicationInterface.c
@@ -131,6 +131,7 @@ void MasterCommunicationInterface_Run_OnInit(void)
 void MasterCommunicationInterface_Run_SetResponse(ConstByteArray_t response)
 {
     /* Begin User Code Section: SetResponse:run Start */
+    i2c_hal_receive();
     i2c_hal_set_tx_buffer(response.bytes, response.count);
     /* End User Code Section: SetResponse:run Start */
     /* Begin User Code Section: SetResponse:run End */

--- a/mcu-firmware/rrrc/components/MasterCommunicationInterface/i2cHal.c
+++ b/mcu-firmware/rrrc/components/MasterCommunicationInterface/i2cHal.c
@@ -96,7 +96,6 @@ static void i2c_hal_on_address_matched(const uint8_t dir)
 {
     if (dir == I2C_DIR_MASTER_TX)
     {
-        descriptor.rxBufferCount = 0u;
         i2c_hal_rx_started();
     }
     else


### PR DESCRIPTION
Previously, if message processing was slow, a second i2c write could have overwritten the first write's message buffer. This can easily lead to inconsistent states.

This PR prevents this by only resetting the write index when the processing is ready with its response.