### PR TITLE
Configure an RTT down buffer

### DIFF
--- a/mcu-bootloader/main.c
+++ b/mcu-bootloader/main.c
@@ -33,7 +33,6 @@ static void clear_rtt() {
     for (uint32_t* pDest = &_srtt; pDest < &_ertt;) {
         *pDest++ = 0;
     }
-
 }
 
 int main(void)

--- a/mcu-common/SEGGER/RTT/SEGGER_RTT_Conf.h
+++ b/mcu-common/SEGGER/RTT/SEGGER_RTT_Conf.h
@@ -92,7 +92,7 @@ Revision: $Rev: 24316 $
 // Down-channel 1: SystemView
 //
 #ifndef   SEGGER_RTT_MAX_NUM_DOWN_BUFFERS
-  #define SEGGER_RTT_MAX_NUM_DOWN_BUFFERS           (0)     // Max. number of down-buffers (H->T) available on this target  (Default: 3)
+  #define SEGGER_RTT_MAX_NUM_DOWN_BUFFERS           (1)     // Max. number of down-buffers (H->T) available on this target  (Default: 3)
 #endif
 
 #ifndef   BUFFER_SIZE_UP


### PR DESCRIPTION
RTT requires a down buffer, otherwise it will write the memory of something else during initialization, which we really don't want.