### PR TITLE
Avoid unconditionally enabling interrupts

### DIFF
--- a/mcu-firmware/rrrc/components/CommWrapper_LedDisplay/CommWrapper_LedDisplay.c
+++ b/mcu-firmware/rrrc/components/CommWrapper_LedDisplay/CommWrapper_LedDisplay.c
@@ -119,9 +119,10 @@ Comm_Status_t CommWrapper_LedDisplay_Run_Command_SetUserFrame_Start(ConstByteArr
             .G = (c & 0x07E0u) >>  5u,
             .B = (c & 0x001Fu) >>  0u
         };
+        uint32_t primask = __get_PRIMASK();
         __disable_irq();
         CommWrapper_LedDisplay_Write_UserFrame(i, rgb565_to_rgb(color));
-        __enable_irq();
+        __set_PRIMASK(primask);
     }
 
     return Comm_Status_Ok;

--- a/mcu-firmware/rrrc/components/CommWrapper_MotorPorts/CommWrapper_MotorPorts.c
+++ b/mcu-firmware/rrrc/components/CommWrapper_MotorPorts/CommWrapper_MotorPorts.c
@@ -218,9 +218,10 @@ Comm_Status_t CommWrapper_MotorPorts_Run_Command_SetControlValue_Start(ConstByte
             *responseCount = 1u;
             return Comm_Status_Error_CommandError;
         }
+        uint32_t primask = __get_PRIMASK();
         __disable_irq();
         CommWrapper_MotorPorts_Write_DriveRequest(portIdx, &request);
-        __enable_irq();
+        __set_PRIMASK(primask);
     }
 
     return Comm_Status_Ok;

--- a/mcu-firmware/rrrc/components/ErrorStorage/ErrorStorage.c
+++ b/mcu-firmware/rrrc/components/ErrorStorage/ErrorStorage.c
@@ -322,6 +322,7 @@ void ErrorStorage_Run_Store(const ErrorInfo_t* data)
     /* Begin User Code Section: Store:run Start */
     if (esInitialized)
     {
+        uint32_t primask = __get_PRIMASK();
         __disable_irq();
         if (errorStorageBlocks[esActiveBlock].allocated == OBJECTS_PER_BLOCK)
         {
@@ -335,7 +336,7 @@ void ErrorStorage_Run_Store(const ErrorInfo_t* data)
 
         _store_object(&errorStorageBlocks[esActiveBlock], &copy, sizeof(ErrorInfo_t));
         _update_number_of_stored_errors();
-        __enable_irq();
+        __set_PRIMASK(primask);
     }
     /* End User Code Section: Store:run Start */
     /* Begin User Code Section: Store:run End */
@@ -385,6 +386,7 @@ void ErrorStorage_Run_Clear(void)
     ASSERT (esInitialized);
 
     /* delete every allocated object */
+    uint32_t primask = __get_PRIMASK();
     __disable_irq();
     for (size_t i = 0u; i < ARRAY_SIZE(errorStorageBlocks); i++)
     {
@@ -398,7 +400,7 @@ void ErrorStorage_Run_Clear(void)
         block->deleted = block->allocated;
     }
     _update_number_of_stored_errors();
-    __enable_irq();
+    __set_PRIMASK(primask);
     /* End User Code Section: Clear:run Start */
     /* Begin User Code Section: Clear:run End */
 

--- a/mcu-firmware/rrrc/components/MasterStatusObserver/MasterStatusObserver.c
+++ b/mcu-firmware/rrrc/components/MasterStatusObserver/MasterStatusObserver.c
@@ -27,6 +27,7 @@ static bool countdown(uint32_t* timer, uint32_t increment)
 {
     bool elapsed = false;
 
+    uint32_t primask = __get_PRIMASK();
     __disable_irq();
     if (*timer != 0u)
     {
@@ -40,7 +41,7 @@ static bool countdown(uint32_t* timer, uint32_t increment)
             *timer -= increment;
         }
     }
-    __enable_irq();
+    __set_PRIMASK(primask);
 
     return elapsed;
 }

--- a/mcu-firmware/rrrc/components/McuStatusCollector/McuStatusCollector.c
+++ b/mcu-firmware/rrrc/components/McuStatusCollector/McuStatusCollector.c
@@ -15,19 +15,20 @@ static bool _read_slot(uint8_t index, uint8_t* pData, uint8_t bufferSize, uint8_
     static uint8_t buffer[64];
 
     *slotSize = 0u;
+    uint32_t primask = __get_PRIMASK();
     __disable_irq();
     SlotData_t slot = McuStatusCollector_Read_SlotData(index);
 
     if (slot.version == versions[index] || ((slot.version & 0x80u) != 0u)) // if highest bit is 1, there is no data
     {
         // data did not change since last read
-        __enable_irq();
+        __set_PRIMASK(primask);
         return true;
     }
 
     // copy bytes in critical section to avoid corruption - TODO do this after the size checks
     memcpy(buffer, slot.data.bytes, slot.data.count);
-    __enable_irq();
+    __set_PRIMASK(primask);
 
     bool slot_fits = true;
 

--- a/mcu-firmware/rrrc/components/McuStatusSlots/McuStatusSlots.c
+++ b/mcu-firmware/rrrc/components/McuStatusSlots/McuStatusSlots.c
@@ -79,6 +79,7 @@ static void update_slot(uint8_t index, const uint8_t* data, uint8_t data_size)
     ASSERT(data_size <= slot->size);
 
     bool slot_changed = true;
+    uint32_t primask = __get_PRIMASK();
     __disable_irq();
     if (!slot_has_data(slot) || data_size != slot->array.count)
     {
@@ -95,20 +96,21 @@ static void update_slot(uint8_t index, const uint8_t* data, uint8_t data_size)
         slot->version = (slot->version + 1u) & 0x7Fu;
         McuStatusSlots_Write_SlotData(index, (const SlotData_t) {.data = slot->array, .version = slot->version});
     }
-    __enable_irq();
+    __set_PRIMASK(primask);
 }
 /* End User Code Section: Declarations */
 
 void McuStatusSlots_Run_Reset(void)
 {
     /* Begin User Code Section: Reset:run Start */
+    uint32_t primask = __get_PRIMASK();
     __disable_irq();
     for (size_t i = 0u; i < ARRAY_SIZE(slots); i++)
     {
         slots[i].array.count = 0u;
         slots[i].version = 0xFFu;
     }
-    __enable_irq();
+    __set_PRIMASK(primask);
 
     uint8_t reset_data = 0x5Au;
     update_slot(STATUS_SLOT_RESET, &reset_data, 1u);

--- a/mcu-firmware/rrrc/components/MotorPortHandler/MotorPortHandler.c
+++ b/mcu-firmware/rrrc/components/MotorPortHandler/MotorPortHandler.c
@@ -50,6 +50,7 @@ static void _init_port(MotorPort_t* port)
     gpio_set_pin_function(GPIO_FROM_FAST_PIN(port->gpio.enc1), GPIO_PIN_FUNCTION_A);
     gpio_set_pin_pull_mode(GPIO_FROM_FAST_PIN(port->gpio.enc1), GPIO_PULL_OFF);
 
+    uint32_t primask = __get_PRIMASK();
     __disable_irq();
 
     _gpio_set_continuous_sampling(GPIO_FROM_FAST_PIN(port->gpio.enc0));
@@ -63,7 +64,7 @@ static void _init_port(MotorPort_t* port)
     /* set dummy library */
     port->library = &motor_library_dummy;
 
-    __enable_irq();
+    __set_PRIMASK(primask);
 }
 
 void MotorPortHandler_Run_OnInit(MotorPort_t* ports, uint8_t portCount)


### PR DESCRIPTION
This PR changes all `__enable_irq` call sites to instead reload the previous interrupt mask value in case other components disable specific IRQs that shouldn't get re-enabled accidentally.