### PR TITLE
Fix `tools.read_errors` and add to documentation

### DIFF
--- a/docs/pi/index.md
+++ b/docs/pi/index.md
@@ -9,3 +9,4 @@ Pi firmware
 - [Connecting to the brain](connect-ssh.md)
 - [Starting and stopping the firmware](start-stop.md)
 - [Working with firmware packages](working-with-packages.md)
+- [Reading the MCU error log](mcu-error-log.md)

--- a/docs/pi/mcu-error-log.md
+++ b/docs/pi/mcu-error-log.md
@@ -1,0 +1,9 @@
+Reading the MCU error log
+-------------------------
+
+The MCU records certain errors. Pi firmware contains tools to read these error records. To do this,
+`ssh` into the brain, then navigate to the most recent installed package (e.g. `RevvyFramework/user/packages/revvy-0.1.1298/`). The following commands are now available:
+
+- `python -m tools.read_errors`: Reads the error log from the MCU.
+- `python -m tools.read_errors --inject-test-error`: Records a test error, then reads the error log.
+- `python -m tools.read_errors --clear`: Reads the error log and then deletes it from the MCU.


### PR DESCRIPTION
This PR just updates the manual tool, but now that this is working we have an example for how to use the APIs. We should be able to integrate this into the autonomous startup process, or expose control over BLE/Wifi