### PR TITLE
Fix deadlock while exiting in a thread wrapper

### DIFF
--- a/pi-firmware/revvy/utils/thread_wrapper.py
+++ b/pi-firmware/revvy/utils/thread_wrapper.py
@@ -42,7 +42,7 @@ class ThreadWrapper:
         self._thread_running_event = Event()
         self._state = ThreadWrapper.STOPPED
         self._is_exiting = False
-        self._thread = Thread(target=self._thread_func, args=(), daemon=True, name=name)
+        self._thread = Thread(target=self._thread_func, args=(), name=name)
         self._thread.start()
 
     def _wait_for_start(self):


### PR DESCRIPTION
It is possible for `MainThread` to call exit and the `RemoteControllerThread` to call `stop` at around the same time, causing a deadlock. This PR fixes this issue, which is necessary for the integrated tests to not hang randomly.

Log of such a deadlock:
```
[4.61][Info][MainThread][ProgrammedRobotController] Stopping programmed robot controller
[4.63][Info][ProgrammedRobotController][ProgrammedRobotController] Exiting control thread
[4.63][Info][MainThread][ThreadWrapper][script_0_button_1] stopping
[4.63][Info][MainThread][ThreadWrapper][script_0_button_1] request stop
[4.63][Info][MainThread][ThreadWrapper][script_0_button_1] resume thread
[4.63][Info][MainThread][ThreadWrapper][script_0_button_1] call stop requested callbacks
[4.63][Info][MainThread][ThreadWrapper][script_0_button_1] stop requested callbacks finished
[5.53][Warning][RemoteControllerThread][RemoteController] Controller lost due to timeout!
[5.53][Info][RemoteControllerThread][RobotManager] Remote controller lost
[5.53][Info][RemoteControllerThread][RobotStatusIndicator] Controller: RemoteControllerStatus.Controlled -> RemoteControllerStatus.ConnectedNoControl
[5.54][Info][script_0_button_1][ErrorHandler] Error QUEUED
[5.55][Info][script_0_button_1][RobotManager] exit requested with code 1
[5.55][Info][script_0_button_1][ThreadWrapper][script_0_button_1] stopped
[5.55][Info][script_0_button_1][ThreadWrapper][script_0_button_1] call stopped callbacks
[5.55][Info][MainThread][ThreadWrapper][RobotStatusUpdaterThread] exiting
[5.55][Info][MainThread][ThreadWrapper][RobotStatusUpdaterThread] stopping
[5.55][Info][MainThread][ThreadWrapper][RobotStatusUpdaterThread] request stop
[5.55][Info][MainThread][ThreadWrapper][RobotStatusUpdaterThread] resume thread
[5.56][Info][RemoteControllerThread][RobotManager] RESET config
[5.56][Info][RemoteControllerThread][RobotStatusIndicator] Robot: RobotStatus.Configured -> RobotStatus.NotConfigured
[5.56][Info][MainThread][ThreadWrapper][RobotStatusUpdaterThread] call stop requested callbacks
[5.56][Info][MainThread][ThreadWrapper][RobotStatusUpdaterThread] stop requested callbacks finished
[5.56][Info][MainThread][ThreadWrapper][RobotStatusUpdaterThread] waiting for stop event to be set
[5.56][Info][RobotStatusUpdaterThread][ThreadWrapper][RobotStatusUpdaterThread] stopped
[5.56][Info][RobotStatusUpdaterThread][ThreadWrapper][RobotStatusUpdaterThread] call stopped callbacks
[5.56][Info][MainThread][ThreadWrapper][RobotStatusUpdaterThread] exited
[5.56][Info][RemoteControllerThread][RobotManager] RC stopped
[5.56][Info][RemoteControllerThread][ThreadWrapper][script_0_button_1] stop already called. Currently in state: 0
[5.57][Info][MainThread][RobotStatusIndicator] Controller: RemoteControllerStatus.ConnectedNoControl -> RemoteControllerStatus.NotConnected
[5.57][Info][RemoteControllerThread][ThreadWrapper][script_0_button_1] stop already called. Currently in state: 0
[5.57][Info][RemoteControllerThread][ThreadWrapper][script_0_button_1] exiting
[5.57][Info][RemoteControllerThread][ThreadWrapper][script_0_button_1] stop already called. Currently in state: 0
[5.57][Info][RemoteControllerThread][ThreadWrapper][script_0_button_1] waiting for stop event to be set
[5.57][Info][RemoteControllerThread][ThreadWrapper][script_0_button_1] exited
[5.57][Info][MainThread][RobotStatusIndicator] Robot: RobotStatus.NotConfigured -> RobotStatus.Stopped
[5.57][Info][RemoteControllerThread][ScriptManager] stop all scripts and reset state
[5.57][Info][MainThread][ThreadWrapper][RemoteControllerThread] exiting
[5.57][Info][RemoteControllerThread][ScriptManager] stop all scripts and reset state
[5.57][Info][MainThread][ThreadWrapper][RemoteControllerThread] stopping
[5.57][Info][MainThread][ThreadWrapper][RemoteControllerThread] request stop
[5.57][Info][MainThread][ThreadWrapper][RemoteControllerThread] resume thread
[5.57][Info][MainThread][ThreadWrapper][RemoteControllerThread] call stop requested callbacks
[5.57][Info][MainThread][ThreadWrapper][RemoteControllerThread] stop requested callbacks finished
[5.57][Info][MainThread][ThreadWrapper][RemoteControllerThread] waiting for stop event to be set
```