### PR TITLE
Avoid attribute error when resource is used by someone else

### DIFF
--- a/pi-firmware/revvy/scripting/resource.py
+++ b/pi-firmware/revvy/scripting/resource.py
@@ -83,7 +83,7 @@ class Resource:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self._lock.__exit__(exc_type, exc_val, exc_tb)
 
-    def reset(self):
+    def reset(self) -> None:
         # self._log('Reset')
         with self._lock:
             handle, self._active_handle = self._active_handle, null_handle
@@ -115,13 +115,13 @@ class Resource:
                 )
                 return null_handle
 
-    def _create_new_handle(self, with_priority, on_taken_away):
+    def _create_new_handle(self, with_priority, on_taken_away) -> None:
         self._current_priority = with_priority
         self._active_handle = ResourceHandle(self)
         if on_taken_away:
             self._active_handle.on_interrupted.add(on_taken_away)
 
-    def release(self, resource_handle):
+    def release(self, resource_handle) -> None:
         with self._lock:
             if self._active_handle == resource_handle:
                 self._active_handle = null_handle


### PR DESCRIPTION
Setup:

button 1: turn robot left
button 2: turn robot right

These scripts will automatically be configured with different priorities. If you press button1 then quickly button2, the robot start turning left, interrupts the first script, then starts turning right. However, pressing button 2 first, then button 1 may end up with an exception.

This PR works around this.