### PR TITLE
Allow interleaving different MCU commands

### DIFF
--- a/docs/mcu-firmware/i2c.md
+++ b/docs/mcu-firmware/i2c.md
@@ -76,8 +76,6 @@ to define higher level commands.
 Commands are firmware procedures that may run for an arbitrarily long time. Multiple different
 commands may run at the same time.
 
-> Currently, we only start one command at a time in the Pi firmware.
-
 ### Format of a request
 
 Requests control the Command execution. The MCU may implement custom Command-specific handling for


### PR DESCRIPTION
This change allows starting a long command, and executing other commands while the first one reports a Pending result. We have a handful of long-running commands only, so this change is not immediately visible to us.