### PR TITLE
Work around issue preventing firmware updates

### DIFF
--- a/mcu-bootloader/rrrc/components/MasterCommunicationInterface_Bootloader/MasterCommunicationInterface_Bootloader.c
+++ b/mcu-bootloader/rrrc/components/MasterCommunicationInterface_Bootloader/MasterCommunicationInterface_Bootloader.c
@@ -48,8 +48,8 @@ void i2c_hal_rx_complete(const uint8_t* buffer, size_t bufferSize, size_t bytesR
     } else {
         messageSize = (ssize_t)bytesReceived;
     }
-    messageReceived = true;
     messageBuffer = buffer;
+    messageReceived = true;
 }
 
 void i2c_hal_tx_complete(void)

--- a/mcu-bootloader/rrrc/runtime/comm_handlers.c
+++ b/mcu-bootloader/rrrc/runtime/comm_handlers.c
@@ -67,6 +67,8 @@ static Comm_Status_t InitializeUpdate_Start(ConstByteArray_t commandPayload, Byt
     size_t firmware_size = get_uint32(&commandPayload.bytes[0]);
     uint32_t checksum = get_uint32(&commandPayload.bytes[4]);
 
+    // TODO: this should be an async server call. The operation takes long and the RPi may time out.
+
     if (!UpdateManager_Run_CheckImageFitsInFlash(firmware_size))
     {
         return Comm_Status_Error_CommandError;
@@ -122,6 +124,7 @@ static Comm_Status_t VersionProvider_GetHardwareVersion_Start(ConstByteArray_t c
         "2.0.0"
     };
 
+    SEGGER_RTT_printf(0, "GetHardwareVersion\n");
     uint32_t hw = HARDWARE_VERSION;
 
     if (hw < ARRAY_SIZE(hw_version_strings))


### PR DESCRIPTION
The RPi Zero W seems to access I2C faster than the v2 which causes it to time out when executing `InitializeUpdateCommand`. This should be properly solved by turning the MCU-side implementation into an async call but this workaround should at least prevent breaking brains for no good reason.