### PR TITLE
Handle long messages on a background thread

### DIFF
--- a/pi-firmware/revvy/bluetooth/longmessage.py
+++ b/pi-firmware/revvy/bluetooth/longmessage.py
@@ -473,6 +473,13 @@ class LongMessageImplementation:
         - FRAMEWORK update that we need to install.
         - ASSET_DATA add new sound to the repertoire
         """
+
+        message_handler_thread = threading.Thread(
+            target=lambda: self.on_message_updated_impl(message), name="LongMessageHandler"
+        )
+        message_handler_thread.start()
+
+    def on_message_updated_impl(self, message: ReceivedLongMessage):
         message_type = message.message_type
 
         self._log(f"Received message: {message_type.name}")
@@ -534,3 +541,5 @@ class LongMessageImplementation:
 
         elif message_type == LongMessageType.ASSET_DATA:
             extract_asset_longmessage(self._storage, self._asset_dir)
+
+        self._log(f"Message {message_type.name} updated")


### PR DESCRIPTION
This change moves (among other things) robot configuration from the BLE thread to a background thread. This change should prevent a long-running configuration from blocking the BLE thread, although doing that shouldn't cause issues normally.

Merging this will also pull in https://github.com/STEAM-Academy-PRO/pybleno/commit/05cdbeef214f83f39abeb7d94bc24be740bb6cea which papers over an exception that breaks BLE.